### PR TITLE
Support custom fixers commited into a '.autofix/fixers/' directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,3 +102,7 @@ Tier 2 (experimental, use with caution):
 
 Tier 3 (you probably don't want to run these):
 - [ ] TODO
+
+## Custom fixers
+
+You can also implement your own fixers (similar to the ones found in the [./fixers/](./fixers/) directory) and commit them to your repository under a `.autofix/fixers/` directory. Autofix will automatically pick them up; run them on your codebase; and commit new fixes when relevant.

--- a/autofix.js
+++ b/autofix.js
@@ -13,7 +13,13 @@ const tiers = String(argv.tiers || 0).split(',').map(tier => parseInt(tier, 10))
 // Detect and register available fixer modules.
 const fixers = [ [], [], [], [] ];
 console.log(`Registering fixer modules`);
-Promise.all(fs.readdirSync(`${__dirname}/fixers`).map(path => Object.assign(require(`${__dirname}/fixers/${path}`), {path})).map(async (fixer) => {
+const loadFixers = (directory) => {
+  return !fs.existsSync(directory) ? [] :
+    fs.readdirSync(directory).map(fixerPath => Object.assign(require(`${directory}/${fixerPath}`), { path: fixerPath }));
+}
+const coreFixers = loadFixers(`${__dirname}/fixers`);
+const customFixers = loadFixers(`${process.cwd()}/.autofix/fixers`);
+Promise.all([...coreFixers, ...customFixers].map(async (fixer) => {
   try {
     if (argv.verbose) {
       console.log(`  Registering ${fixer.path}...`);


### PR DESCRIPTION
Support repository-local fixer modules, sourced from a repository's `.autofix/fixers/` directory.

Proof-of-concept: https://github.com/gitpod-io/workspace-images/pull/790/files

<a href="https://gitpod.io/#https://github.com/autofix-dev/autofix/pull/16"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

